### PR TITLE
Update imports.py

### DIFF
--- a/dev/local/imports.py
+++ b/dev/local/imports.py
@@ -37,8 +37,6 @@ from IPython.core.debugger import set_trace
 pd.options.display.max_colwidth = 600
 NoneType = type(None)
 
-Tensor.ndim = property(lambda x: x.dim())
-
 def is_iter(o):
     "Test whether `o` can be used in a `for` loop"
     #Rank 0 tensors in PyTorch are not really iterable


### PR DESCRIPTION
ndim was added to pytorch since 1.2.0
Monkey patching is no longer required, since  pytorch>=1.2.0 is in environment.yml
https://pytorch.org/docs/stable/tensors.html?highlight=ndim#torch.Tensor.ndim