### PR TITLE
Fix test in 02_transforms

### DIFF
--- a/dev/02_transforms.ipynb
+++ b/dev/02_transforms.ipynb
@@ -83,7 +83,7 @@
     "def f(x) -> float: return x\n",
     "test_eq(anno_ret(f), float)\n",
     "def f(x) -> Tuple[float,float]: return x\n",
-    "test_eq(anno_ret(f), Tuple[float,float])\n",
+    "test_eq(anno_ret(f), [float,float])\n",
     "def f(x) -> None: return x\n",
     "test_eq(anno_ret(f), NoneType)\n",
     "def f(x): return x\n",


### PR DESCRIPTION
It looks like recently, this test was broken in 02_transforms: 

```
def f(x) -> Tuple[float,float]: return x
test_eq(anno_ret(f), Tuple[float,float])
```

This will fix that by changing it to:

```
def f(x) -> Tuple[float,float]: return x
test_eq(anno_ret(f), [float,float])
```

Which is what I believe it should be based on `anno_ret` conditional with Tuples.  