### PR TITLE
Attempt to fix source links for TypeDispatch properties

### DIFF
--- a/dev/92_notebook_showdoc.ipynb
+++ b/dev/92_notebook_showdoc.ipynb
@@ -19,7 +19,6 @@
     "from local.imports import *\n",
     "from local.notebook.core import *\n",
     "from local.notebook.export import *\n",
-    "from local.data.transform import TypeDispatch\n",
     "import inspect,enum,nbconvert\n",
     "from IPython.display import Markdown,display\n",
     "from IPython.core import page\n",
@@ -311,8 +310,8 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def is_type_dispatch(o):\n",
-    "    return issubclass(type(o), TypeDispatch)"
+    "def is_type_dispatch(x):\n",
+    "    return x.__class__.__name__ == \"TypeDispatch\""
    ]
   },
   {
@@ -322,10 +321,10 @@
    "outputs": [],
    "source": [
     "#export\n",
-    "def unwrapped_type_dispatch_func(td):\n",
-    "    if not is_type_dispatch(td): return td\n",
-    "    types = [f for f in td.funcs]\n",
-    "    return td.funcs[types[0]]"
+    "def unwrapped_type_dispatch_func(x):\n",
+    "    if not is_type_dispatch(x): return x\n",
+    "    types = [f for f in x.funcs]\n",
+    "    return x.funcs[types[0]]"
    ]
   },
   {
@@ -401,6 +400,7 @@
     "\n",
     "def get_source_link(func, local=False, is_name=None):\n",
     "    \"Return a link to the notebook where `func` is defined.\"\n",
+    "    func = unwrapped_type_dispatch_func(func)\n",
     "    pref = '' if local else FASTAI_NB_DEV\n",
     "    is_name = is_name or isinstance(func, str)\n",
     "    src = source_nb(func, is_name=is_name, return_all=True)\n",

--- a/dev/92_notebook_showdoc.ipynb
+++ b/dev/92_notebook_showdoc.ipynb
@@ -19,6 +19,7 @@
     "from local.imports import *\n",
     "from local.notebook.core import *\n",
     "from local.notebook.export import *\n",
+    "from local.data.transform import TypeDispatch\n",
     "import inspect,enum,nbconvert\n",
     "from IPython.display import Markdown,display\n",
     "from IPython.core import page\n",
@@ -310,10 +311,35 @@
    "outputs": [],
    "source": [
     "#export\n",
+    "def is_type_dispatch(o):\n",
+    "    return issubclass(type(o), TypeDispatch)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#export\n",
+    "def unwrapped_type_dispatch_func(td):\n",
+    "    if not is_type_dispatch(td): return td\n",
+    "    types = [f for f in td.funcs]\n",
+    "    return td.funcs[types[0]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#export\n",
     "SOURCE_URL = \"https://github.com/fastai/fastai_docs/tree/master/dev/\"\n",
     "\n",
     "def get_function_source(func):\n",
     "    \"Return link to `func` in source code\"\n",
+    "    func = unwrapped_type_dispatch_func(func)\n",
     "    try: line = inspect.getsourcelines(func)[1]\n",
     "    except Exception: return ''\n",
     "    module = inspect.getmodule(func).__name__.replace('.', '/') + '.py'\n",


### PR DESCRIPTION
TypeDispatch functions are unwrapped so `get_function_source` works
for`encodes` and `decodes` Transform methods.

`get_function_source` relies on `inspect.getsourcelines()`, which
expects some sort of callable object. However, `encodes` and `decodes`
are of type TypeDispatch, and `get_function_source` returns an empty
string. This, in turn, causes `show_doc` to generate an empty link.

When the notebook is exported to local/notebook/showdoc, it fixes the
source links for `Cuda.encodes` that were demonstrated during today's
code walk-thru in notebook `05_data_core`. The same thing would happen
for other transform encoding/decoding implementations such as those of
`OneHotEncode`.

~~Note that the source link for these methods points to a github revision,
whereas the links for other objects are generally resolved to
`nbviewer` URLs. I'm not sure if this is intentional or what the rules
are.~~

Link to `nbviewer` addressed in https://github.com/fastai/fastai_dev/pull/170/commits/8785fd1b41430bc9fa39dd3047624b7a1c283815#diff-3052dab1598d14c3e070a3fbdc8bf3e7R403

~~**IMPORTANT**: running the modified notebook causes `05_data_core` to
fail due to some sort of cyclic dependency that I'm not sure how to resolve - 
extract `TypeDispatch` to a different notebook? I need to look further into it.~~

Addressed in https://github.com/fastai/fastai_dev/pull/170/commits/8785fd1b41430bc9fa39dd3047624b7a1c283815#diff-3052dab1598d14c3e070a3fbdc8bf3e7R314, as suggested by @jph00. 