### PR TITLE
Fixed parent_label bug and added new test

### DIFF
--- a/dev/05_data_core.ipynb
+++ b/dev/05_data_core.ipynb
@@ -72,7 +72,7 @@
     {
      "data": {
       "text/plain": [
-       "(#2) [/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3,/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/7]"
+       "(#2) [/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7,/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/3]"
       ]
      },
      "execution_count": null,
@@ -138,7 +138,7 @@
     {
      "data": {
       "text/plain": [
-       "(#709) [/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/8055.png,/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/9466.png,/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/7778.png,/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/8824.png,/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/8228.png,/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/9620.png,/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/8790.png,/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/7497.png,/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/7383.png,/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/9324.png...]"
+       "(#709) [/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/9243.png,/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/9519.png,/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/7534.png,/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/9082.png,/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/8377.png,/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/994.png,/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/8559.png,/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/8217.png,/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/8571.png,/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/8954.png...]"
       ]
      },
      "execution_count": null,
@@ -740,12 +740,12 @@
     {
      "data": {
       "text/plain": [
-       "([PosixPath('/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/8055.png'),\n",
-       "  PosixPath('/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/9466.png'),\n",
-       "  PosixPath('/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/train/3/7778.png')],\n",
-       " [PosixPath('/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/valid/3/957.png'),\n",
-       "  PosixPath('/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/valid/3/9073.png'),\n",
-       "  PosixPath('/home/jhoward/git/fastai_dev/dev/data/mnist_tiny/valid/3/8939.png')])"
+       "([PosixPath('/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/9243.png'),\n",
+       "  PosixPath('/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/9519.png'),\n",
+       "  PosixPath('/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/train/7/7534.png')],\n",
+       " [PosixPath('/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/valid/7/9294.png'),\n",
+       "  PosixPath('/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/valid/7/9257.png'),\n",
+       "  PosixPath('/Users/amanarora/GIT_Repos/fastai_dev/dev/data/mnist_tiny/valid/7/8175.png')])"
       ]
      },
      "execution_count": null,
@@ -794,7 +794,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAEQAAABUCAYAAAA7xZEpAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4xLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+17YcXAAAEeUlEQVR4nO3bX4iNeRzH8dfPUNQQZUZpUDY1tWVTwlJMLuzFElLaDRfKjVwgN1yIGtSUq73YG4mylCxJoVxoL5a4WDdM1rZhS4iQKeTPevZi9pkz85vDnDHnzHPW/t51Ouc5v/M8z7fP+Tzf3+/3/T1PyLJMosSIogOoN5IgEUmQiCRIRBIkIgkSkQSJKFyQEMJPIYQHIYSuEMIfIYQNhcZT9MAshPAl/syy7HUIoRW/4Nssy34rIp7CHZJlWWeWZa/zzX9fXxQVT+GCQAjhxxDCS/yOBzhXWCxFXzI5IYQGfI02dGRZ9raIOOrCIZBl2d9Zlv2KFmwsKo66EaQXI/1fc0gIoTmE8F0IoTGE0BBC+Abf42JhMRWZQ0IITfgZX+n+c/7CD1mWHSgspnpJqvVCPeaQQkmCRCRBIpIgESMHaP+cM24o92VySEQSJCIJEpEEiUiCRCRBIpIgEQONQ4aNFy9egIMHD4LNmzeD1atXg2PHjoGGhoaaxpEcEjHQ9L+mI9VLly6BV69e6ejoABcvlq8NdXZ2gtbW1mqdPo1UK2FYc8jjx4/BkSNHwI4dO8C7d+8G3PfGjRuoqkPKkhwSMSw55OjRo2DXrl3gzp07fdonTJjQ8/nZs2d92qZNmwZu3boFRo0aVY2QSDmkMoYlhzx58gT9nbF+/XqwdetW27dvB+fO9V3F3LZtG6rqjI+SHBIxLA7ZtGkTuH79Oli2bBlYsmQJaG9v7+eMsWPHgqVLlw5HiD0kh0QUMlK9ffs22LdvHzh06FBP2/jx48G1a9dQ6mVqQOplKqEQhzQ2NqJ7DhOTz2UWLVpUi1P3JjmkEgpxyJgxY8CbN2/6tU2cOBFs3Nh9z8zixYvBggULUNV6SHJIJdSdQz7EnDlzwP79+0FLSwuG1AuVdUghgty8eROcPn0aLF++vKft8OHD4OrVq332uXfvHrh79y5YsWIFOHny5KeGkS6ZSii0hDgYnj59Ctra2lCaMOZOyi+hQZAcUgk1cUh+zPx9xIjq6Z47Yv78+dBTNti7d+9gD5UcUglVnf6fOXMG3L9/H6xcuRJMmjSpauc4e/Zsn+0LFy7gkxxSluSQiKrmkNmzZ4OmpiZw/vz5T42rHw8fPgSzZs0Cjx49ApcvXwZz584d7CFTDqmEquSQK1euoLTcmI8VhsL79+/B7t27wYED3Xd7587I89LkyZOHfK7eJIdEVMUhM2fOBFOnTkXJMevWrQM7d+7s8/sZM2agNC95+7b0rFC+zJkf40OL32vXrgVTpkwZcvy9SQ6JqGovs2rVKpRmsR9izZo14NSpUyhfSozJC0fHjx8H8+bNA6NHjx5MiL1JvUwlVNUhXV1dKN3+1N7eDp4/f47KnJDPe5qbm1Fy3ZYtW8D06dMHE9LHSA6phGGph+Q3u+zZswecOHECLFy4EGzYUHq6fdy4cSgtd9aQ5JBK+M9UzGpAckglJEEikiARSZCIJEhEEiQiCRIxUD2kbF/9OZMcEpEEiUiCRCRBIpIgEUmQiH8AXEReOybNeDQAAAAASUVORK5CYII=\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFkAAABlCAYAAAAms095AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvOIA7rQAABCFJREFUeJztm00obWsYx3+vj6JzDcjHLbltdQcUA18TMZUiJkpS52RCGciEKfmYKFHHjMm9yoTuECUjZ6AkQ0o5Kcq5ReQaYa87cN6923vbcc7Znnft5fmVttZa7fWsX//e/b7PWst4nofytmS4LuA9oJIFUMkCqGQBVLIAKlkAlSxAoCQbY/6L+3s0xnx2XVeW6wJSied5v9n/jTEfgG/AqruKnghUkuPoAv4FdlwXEmTJn4C/PR/0DYwPakg5xpg/gK/An57nfXVdT1CT/BH44gfBEGzJf7kuwhK44cIY0whsAb97nnfruh4IZpI/Af/4RTAEMMl+JIhJ9h0qWQCVLIBKFkC6QRTkX1mTbIcmWQCVLIBKFkAlC6CSBVDJAqhkAVSyACpZAJUsgEoWwJcPt/T39wOwuLgIQGNjIwBNTU0xn1VVVQCUlpYCcH5+DkAoFMKYpK0EcTTJAkjffnrVyXZ3dwFobm4G4OHhASBpOisqKgA4OjoCoKGhIXKsvb6+vj4AampqAKitrQUgOzv7By8hKdqFc4kvk2zZ2NgAoK2tLeWF5ObmAjA1NQXA0NAQAJmZmT/7lZpkl/g6yff39wAsLy8DcHNzA8DCwgIAZ2dnMcfZaykpKUkYky8vLwF4fHyM2W6PGxgYAGBiYgKAoqKiHykVNMlu8XWSX+Lk5ASAq6urmO11dXUJM5HDw0MA7u7uALi+vgagpaXlqbDvHkKhEADHx8cAZGW9eimhSXZJWif5VwiHwwD09PQAsLoa+9bD+vo6AK2tra/9Sk2yS3zZu5DAzjIuLi6AxNmGHbtTgSZZgHeb5IODAwB2dp5/Oaq+vj5l53p3km9vn54NHxwcfHZ/d3c3AGVlZSk7pw4XArybJNsfsrm5OQD29/eBxPbp2NgYABkZqcufJlmAwCfZTs3Gx8cBmJ2dBRITPDk5CUB5eXnKa9AkCxD4ZfXS0hIQvTkbKeT7dRcXFwNwenoKQE5Ozs+eSpfVLgnkmBwOh9ne3gZgdHT02WPy8vKA6E3bX0jwi2iSBQhkkqenpyPz3XjsGLy2tga8zWwiHk2yAIGYXdgG/ObmJgAdHR2RVqalsLAQgL29PSB6mymF6OzCJYEYk20for29PbItfkU3MjICvEmCX0STLEBaJtmOt/YBw87OTiC6igPIz88HoKurC4Dh4WHJEmPQJAuQlkm2D55UV1c/u7+3t5f5+XkgOqtwiSZZgLRM8tbWFpB4G7+yshKAmZkZXyTYokkWIC2TbJNrP+1DgysrKwAUFBS4KSwJmmQBAtG78Anau3CJShZAJQsgPbvwz7u4gmiSBVDJAqhkAVSyACpZAJUsgEoWQCULoJIFUMkCqGQBVLIAKlkAlSyAShZAJQugkgVQyQKoZAFUsgAqWQCVLIBKFuB/wOgdLggx7Q0AAAAASUVORK5CYII=\n",
       "text/plain": [
        "<Figure size 72x72 with 1 Axes>"
       ]
@@ -1229,7 +1229,7 @@
     "tfm = Cuda()\n",
     "t = tfm((tensor(1),))\n",
     "test_eq(*t,1)\n",
-    "test_eq(t[0].type(),'torch.cuda.LongTensor')"
+    "test_eq(t[0].type(),'torch.cuda.LongTensor' if default_device().type=='gpu' else 'torch.LongTensor')"
    ]
   },
   {


### PR DESCRIPTION
Inside parent_label, there is a bug in the else part of the function. 
When function is called for type str, `else o.split(os.path.sep)[-1]`
returns the current file name and not parent name.,
This PR fixes that and also new test has been added for the same.