### PR TITLE
Fix test for CPU only machine

### DIFF
--- a/dev/05_data_core.ipynb
+++ b/dev/05_data_core.ipynb
@@ -1373,7 +1373,7 @@
     "x,y  = tdl.one_batch()\n",
     "xd,yd = tdl.after_batch.decode((x,y))\n",
     "\n",
-    "test_eq(x.type(), 'torch.cuda.FloatTensor')\n",
+    "test_eq(x.type(), 'torch.cuda.FloatTensor' if default_device().type=='cuda' else 'torch.FloatTensor')\n",
     "test_eq(xd.type(), 'torch.FloatTensor')\n",
     "assert x.mean()<0.0\n",
     "assert x.std()>0.5\n",


### PR DESCRIPTION
For normalization pipeline which includes `CUDA()`, if machine does not have GPU then `test_eq(x.type(), 'torch.cuda.FloatTensor')` test fails.
This PR fixes that.