### PR TITLE
Categorize to raise error on unseen label with add_na=False

### DIFF
--- a/dev/05_data_core.ipynb
+++ b/dev/05_data_core.ipynb
@@ -477,7 +477,7 @@
     "            items = L(o for o in L(col, use_list=True).unique() if o==o)\n",
     "            if sort: items = items.sorted()\n",
     "        self.items = '#na#' + items if add_na else items\n",
-    "        self.o2i = defaultdict(int, self.items.val2idx())\n",
+    "        self.o2i = defaultdict(int, self.items.val2idx()) if add_na else dict(self.items.val2idx())\n",
     "    def __eq__(self,b): return all_equal(b,self)"
    ]
   },
@@ -489,7 +489,8 @@
    "source": [
     "t = CategoryMap([4,2,3,4])\n",
     "test_eq(t, [2,3,4])\n",
-    "test_eq(t.o2i, {2:0,3:1,4:2})"
+    "test_eq(t.o2i, {2:0,3:1,4:2})\n",
+    "test_fail(lambda: t.o2i['unseen label'])"
    ]
   },
   {

--- a/dev/local/data/core.py
+++ b/dev/local/data/core.py
@@ -103,7 +103,7 @@ class CategoryMap(CollBase):
             items = L(o for o in L(col, use_list=True).unique() if o==o)
             if sort: items = items.sorted()
         self.items = '#na#' + items if add_na else items
-        self.o2i = defaultdict(int, self.items.val2idx())
+        self.o2i = defaultdict(int, self.items.val2idx()) if add_na else dict(self.items.val2idx())
     def __eq__(self,b): return all_equal(b,self)
 
 #Cell


### PR DESCRIPTION
This is not a super big deal (I was even contemplating whether raising this makes sense), nonetheless submitting a PR :slightly_smiling_face:

`Categorize` works as expected with `add_na=True`, but with `add_na` we get the following behavior:

![image](https://user-images.githubusercontent.com/2444926/64709590-d25da680-d4b6-11e9-9eef-5f481db372f3.png)

I am assuming this can potentially lead to subtle bugs.

Anyhow, really not sure if the proposed change is a step in the right direction :slightly_smiling_face: Happy to make any changes to the PR that might be needed or to close it altogether! 