### PR TITLE
Allow cross-reference links to work for properties

### DIFF
--- a/dev/91_notebook_export.ipynb
+++ b/dev/91_notebook_export.ipynb
@@ -843,21 +843,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#export \n",
-    "def get_name(obj):\n",
-    "    \"Get the name of `obj`\"\n",
-    "    if hasattr(obj, '__name__'):       return obj.__name__\n",
-    "    elif getattr(obj, '_name', False): return obj._name\n",
-    "    elif hasattr(obj,'__origin__'):    return str(obj.__origin__).split('.')[-1] #for types\n",
-    "    else:                              return str(obj).split('.')[-1]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -884,6 +869,39 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We need to get the name of the object we are looking for, and then we'll try to find it in our index file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#export \n",
+    "def _get_property_name(p):\n",
+    "    \"Get the name of property `p`\"\n",
+    "    if hasattr(p, 'fget'):\n",
+    "        if hasattr(p.fget, 'func'):\n",
+    "            return p.fget.func.__qualname__\n",
+    "        else:\n",
+    "            return p.fget.__qualname__\n",
+    "    else:\n",
+    "        return next(iter(re.findall(r'\\'(.*)\\'', str(p)))).split('.')[-1]\n",
+    "\n",
+    "def get_name(obj):\n",
+    "    \"Get the name of `obj`\"\n",
+    "    if hasattr(obj, '__name__'):       return obj.__name__\n",
+    "    elif getattr(obj, '_name', False): return obj._name\n",
+    "    elif hasattr(obj,'__origin__'):    return str(obj.__origin__).split('.')[-1] #for types\n",
+    "    elif type(obj)==property:          return _get_property_name(obj)\n",
+    "    else:                              return str(obj).split('.')[-1]"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -906,6 +924,30 @@
     "assert get_name(in_ipython) == 'in_ipython'\n",
     "assert get_name(DocsTestClass.test) == 'test'\n",
     "# assert get_name(Union[Tensor, float]) == 'Union'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For properties defined using `property` or our own `add_props` helper, we approximate the name by looking at their getter functions, since we don't seem to have access to the property name itself. If everything fails (a getter cannot be found), we return the name of the object that contains the property. This suffices for `source_nb` to work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "class PropertyClass:\n",
+    "    p_lambda = property(lambda x: x)\n",
+    "    def some_getter(self): return 7\n",
+    "    p_getter = property(some_getter)\n",
+    "\n",
+    "assert get_name(PropertyClass.p_lambda) == 'PropertyClass.<lambda>'\n",
+    "assert get_name(PropertyClass.p_getter) == 'PropertyClass.some_getter'\n",
+    "assert get_name(PropertyClass) == 'PropertyClass'"
    ]
   },
   {
@@ -981,6 +1023,18 @@
     "#Test return_all\n",
     "#assert source_nb(DocsTestClass, return_all=True) == ('DocsTestClass','90_notebook_core.ipynb')\n",
     "#assert source_nb(DocsTestClass.test, return_all=True) == ('DocsTestClass','90_notebook_core.ipynb')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#hide\n",
+    "# Commented out to avoid circ ref - uncomment to test manually\n",
+    "# from local.data.core import *\n",
+    "# assert source_nb(DataBunch.train_dl) == '05_data_core.ipynb'"
    ]
   },
   {

--- a/dev/92_notebook_showdoc.ipynb
+++ b/dev/92_notebook_showdoc.ipynb
@@ -312,7 +312,16 @@
    "source": [
     "#export\n",
     "def _is_type_dispatch(x): return x.__class__.__name__ == \"TypeDispatch\"\n",
-    "def _unwrapped_type_dispatch_func(x): return next(iter(x.funcs.values())) if _is_type_dispatch(x) else x"
+    "def _unwrapped_type_dispatch_func(x): return next(iter(x.funcs.values())) if _is_type_dispatch(x) else x\n",
+    "\n",
+    "def _is_property(x): return type(x)==property\n",
+    "def _has_property_getter(x): return _is_property(x) and hasattr(x, 'fget') and hasattr(x.fget, 'func')\n",
+    "def _property_getter(x): return x.fget.func if _has_property_getter(x) else x\n",
+    "\n",
+    "def _unwrapped_func(x):\n",
+    "    x = _unwrapped_type_dispatch_func(x)\n",
+    "    x = _property_getter(x)\n",
+    "    return x"
    ]
   },
   {
@@ -326,7 +335,7 @@
     "\n",
     "def get_source_link(func):\n",
     "    \"Return link to `func` in source code\"\n",
-    "    func = _unwrapped_type_dispatch_func(func)\n",
+    "    func = _unwrapped_func(func)\n",
     "    try: line = inspect.getsourcelines(func)[1]\n",
     "    except Exception: return ''\n",
     "    module = inspect.getmodule(func).__name__.replace('.', '/') + '.py'\n",
@@ -342,7 +351,8 @@
     "#hide\n",
     "# Commented out to avoid circ ref - uncomment to test manually\n",
     "# from local.data.core import *\n",
-    "# get_source_link(Categorize.encodes)"
+    "# assert get_source_link(Categorize.encodes).startswith(SOURCE_URL + 'local/data/core.py')\n",
+    "# assert get_source_link(DataBunch.train_dl).startswith(SOURCE_URL + 'local/data/core.py')"
    ]
   },
   {

--- a/dev/local/notebook/export.py
+++ b/dev/local/notebook/export.py
@@ -257,11 +257,22 @@ def notebook2script(fname=None, all_fs=None, up_to=None, silent=False, to_pkl=Fa
     [_notebook2script(f, silent=silent, to_pkl=to_pkl) for f in fnames]
 
 #Cell
+def _get_property_name(p):
+    "Get the name of property `p`"
+    if hasattr(p, 'fget'):
+        if hasattr(p.fget, 'func'):
+            return p.fget.func.__qualname__
+        else:
+            return p.fget.__qualname__
+    else:
+        return next(iter(re.findall(r'\'(.*)\'', str(p)))).split('.')[-1]
+
 def get_name(obj):
     "Get the name of `obj`"
     if hasattr(obj, '__name__'):       return obj.__name__
     elif getattr(obj, '_name', False): return obj._name
     elif hasattr(obj,'__origin__'):    return str(obj.__origin__).split('.')[-1] #for types
+    elif type(obj)==property:          return _get_property_name(obj)
     else:                              return str(obj).split('.')[-1]
 
 #Cell

--- a/dev/local/notebook/showdoc.py
+++ b/dev/local/notebook/showdoc.py
@@ -87,12 +87,21 @@ def add_doc_links(text):
 def _is_type_dispatch(x): return x.__class__.__name__ == "TypeDispatch"
 def _unwrapped_type_dispatch_func(x): return next(iter(x.funcs.values())) if _is_type_dispatch(x) else x
 
+def _is_property(x): return type(x)==property
+def _has_property_getter(x): return _is_property(x) and hasattr(x, 'fget') and hasattr(x.fget, 'func')
+def _property_getter(x): return x.fget.func if _has_property_getter(x) else x
+
+def _unwrapped_func(x):
+    x = _unwrapped_type_dispatch_func(x)
+    x = _property_getter(x)
+    return x
+
 #Cell
 SOURCE_URL = "https://github.com/fastai/fastai_dev/tree/master/dev/"
 
 def get_source_link(func):
     "Return link to `func` in source code"
-    func = _unwrapped_type_dispatch_func(func)
+    func = _unwrapped_func(func)
     try: line = inspect.getsourcelines(func)[1]
     except Exception: return ''
     module = inspect.getmodule(func).__name__.replace('.', '/') + '.py'


### PR DESCRIPTION
Both `source_nb` and `show_doc` should work correctly now. Use, for example, `DataBunch.train_dl` to test - I added a couple of tests in the notebook, but commented out to avoid circular references.

Note, however, that the qualified name returned by `get_name` is an approximation (it points to the name of the property getter, if it exists; or the name of the object that owns the property). I couldn't find a way to obtain the actual name of the property. However, this approach suffices to make the relevant cross-reference functions work: `source_nb`, `get_source_link`, `show_doc`.

Addresses #187.