### PR TITLE
Transform refactor docs

### DIFF
--- a/dev/02_data_transforms.ipynb
+++ b/dev/02_data_transforms.ipynb
@@ -535,13 +535,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A `Transform` is basically a function that can potentially be decoded (for showing purposes). It handles type dispatch via param annotations and delegates `__call__` and `decode` to `encodes` and `decodes`, doing nothing if param annotation doesn't match type. If called with listy `x` then it calls the corresponding function with each item (unless `as_item=True`, in which case it's passed directly as a whole). The function (if matching 1st param type) will cast the result to the same as the input type if the input type is a subclass of the return type (aka if you pass a `TensorImage` but return a `Tensor`, it will be cast to `TensorImage` automatically)  unless you use a return annotation that is `None` (in which case no casting is done).\n",
+    "A `Transform` is the main building block of the fastai data pipelines. In the most general terms a transform can be any function you want to apply to your data, however the `Transform` class provides several mechanisms that make the process of building them easy and flexible.\n",
     "\n",
-    "You can force the value of `as_item` to always be `True` or `False` by setting `as_item_force`. The `order` of a `Transform` will be looked when you compose several of them in a `Pipeline` and they will be sorted by that attribute. If `filt` is set, this transform will only be applied to one of the subsets of a `DataSource` (`0` for the training set, `1` for the validation set).\n",
+    "### The main `Transform` features:\n",
     "\n",
-    "You can either subclass `Transform` and override `encodes`/`decodes` or pass them in the init (as `enc` or `dec`). Note that in the later, `enc` and `dec` won't have access to `self` so you won't be able to use any internal state of the `Transform`. When subclassing `Transform`, you can also add a `setup` method for initial preprocessing.\n",
+    "- **Type dispatch** - Type annotations are used to determine if a transform should be applied to the given argument. It also gives an option to provide several implementations and it choses the one to run based on the type. This is useful for example when running both independent and dependent variables through the pipeline where some transforms only make sense for one and not the other. Another usecase is designing a transform that handles different data formats. Note that if a transform takes multiple arguments only the type of the first one is used for dispatch. \n",
+    "- **Handling of tuples** - When a tuple (or another collection satisfying `is_listy`) of data is passed to a transoform it will get applied to each element separately. Most comonly it will be a *(x,y)* tuple, but it can be anything for example a list of images. You can opt out of this behavior by setting `as_item` or `as_item_force`\n",
+    "- **Reversability** - A transform can be made reversible by implementing the `decode` method. This is mainly used to turn something like a tensor of data which lacks any semantic information back into something understandable by humans like an image, text, or audio.\n",
+    "- **Type propagation** - Whenever possible a transform tries to return data of the same type it received. Mainly used to maintain semantics of things like `TensorImage` which is a thin wrapper of pytorches `Tensor`. You can opt out of this behavior by adding `->None` return type annotation.\n",
+    "- **Preprocessing** - The `setup` method can be used to perform any one-time calculations to be later used by the transform, for example generating a vocabulary to encode categorical data.\n",
+    "- **Filtering based on the dataset type** - By setting the `filt` flag you can make the transform be used only in a specific `DataSource`s like in training, but not validation.\n",
+    "- **Ordering** - You can set the `order` attribute wchich the `Pipeline` uses when it needs to merge two lists of transforms.\n",
+    "- **Appending new behavior with decorators** - You can easily extend an existing `Transform` by creating new `encodes` or `decodes` functions outside the transform definition and decorating them with the transform class. This can be used by the fastai library users to add their own behavior, or multiple modules contributing to the same transform.\n",
     "\n",
-    "Behind the scenes, `__call__` and `decode` call the `_call` method which will first analyze if the transform should be applied (depending on `filt`) then test if `x` is listy or not. In the first case (unless `as_item` is `True` or forced) it will delegate each element of `x` to `_do_call`, in the second, send it as a whole. `_do_call` then calls `encodes` or `decodes`, which are `TypeDispatch` objects. "
+    "### Defining a `Transform`\n",
+    "There are few ways to create a transform with different ratios of simplicity to flexibility.\n",
+    "- **Extending the `Transform` class** - Use inheritence to implement the methods you want\n",
+    "- **Passing methods to the constructor** - Instatiate the `Transform` class and pass your functions as `enc` and `dec` arguments.\n",
+    "- **@Transform decorator** - Turn any function into a `Transform` by just adding a decorator, very straightforward if all you need is a single `encodes` implementation.\n",
+    "- **Passing a function to fastai APIs** - Same as above, but when passing a function to other transform aware classes like `Pipeline` or `TfmdDS` you don't even need a decorator. Your function will get converted to a `Transform` automatically."
    ]
   },
   {


### PR DESCRIPTION
Reading code in notebooks is great to understand how things work but not always why things exist and why they are done the way they are. Jeremy has explained the rationale behind Transform well in his walk-thrus and I'm trying to distill it into the notebook.

The main idea here is to use the text to explain what we want from Transform and leave the details on how to use it in the code examples.