### PR TITLE
Add new test for `all_disjoint`

### DIFF
--- a/dev/06_data_source.ipynb
+++ b/dev/06_data_source.ipynb
@@ -80,6 +80,7 @@
    "outputs": [],
    "source": [
     "assert not all_disjoint(sets)\n",
+    "assert not all_disjoint([[1,2],[4,4]])\n",
     "assert all_disjoint([[1,2],[3,4]])\n",
     "assert all_disjoint([[1,2],[]])\n",
     "assert all_disjoint([[1,2]])\n",

--- a/dev/local/test.py
+++ b/dev/local/test.py
@@ -20,7 +20,7 @@ def test_fail(f, msg='', contains=''):
 def test(a, b, cmp,cname=None):
     "`assert` that `cmp(a,b)`; display inputs and `cname or cmp.__name__` if it fails"
     if cname is None: cname=cmp.__name__
-    assert cmp(a,b),f"{cname}:\n{a}\n{b}"
+    assert cmp(a,b) and cmp(b,a),f"{cname}:\n{a}\n{b}"
 
 #Cell
 def nequals(a,b):


### PR DESCRIPTION
Adding a new test for `all_disjoint`.

My understanding of `all_disjoint` is that each number in all sets passed to `all_disjoint` should be different. Therefore, two sets `[1,2]` and `[4,4]` should not be disjoint.

However, if this is not the case and I've understood the test wrong, then `all_disjoint` function might have to be updated. 