### PR TITLE
Fix test for Datasource, Retrieve one item

### DIFF
--- a/dev/06_data_source.ipynb
+++ b/dev/06_data_source.ipynb
@@ -256,7 +256,7 @@
    "source": [
     "inp = pd.DataFrame(dict(a=[5,1,2,3,4]))\n",
     "dsrc = DataSource(inp, tfms=itemgetter(0)).subset(0)\n",
-    "test_eq(*dsrc[2], (2,))          # Retrieve one item (subset 0 is the default)\n",
+    "test_eq(*dsrc[2], 2)          # Retrieve one item (subset 0 is the default)\n",
     "test_eq(dsrc[1,2], [(1,),(2,)])    # Retrieve two items by index\n",
     "mask = [True,False,False,True,False]\n",
     "test_eq(dsrc[mask], [(5,),(3,)])   # Retrieve two items by mask"


### PR DESCRIPTION
- 06_data_source.ipynb

Fix test

```
inp = pd.DataFrame(dict(a=[5,1,2,3,4]))
dsrc = DataSource(inp, tfms=itemgetter(0)).subset(0)
test_eq(*dsrc[2], (2,))          # Retrieve one item (subset 0 is the default)
test_eq(dsrc[1,2], [(1,),(2,)])    # Retrieve two items by index
mask = [True,False,False,True,False]
test_eq(dsrc[mask], [(5,),(3,)])   # Retrieve two items by mask

```

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-22-1fbb307a45fd> in <module>
      1 inp = pd.DataFrame(dict(a=[5,1,2,3,4]))
      2 dsrc = DataSource(inp, tfms=itemgetter(0)).subset(0)
----> 3 test_eq(*dsrc[2], (2,))          # Retrieve one item (subset 0 is the default)
      4 test_eq(dsrc[1,2], [(1,),(2,)])    # Retrieve two items by index
      5 mask = [True,False,False,True,False]

/opt/insop_workspace/insop_dkr/fastai/fastai_dev/dev/local/test.py in test_eq(a, b)
     31 def test_eq(a,b):
     32     "`test` that `a==b`"
---> 33     test(a,b,equals, '==')
     34 
     35 #Cell

/opt/insop_workspace/insop_dkr/fastai/fastai_dev/dev/local/test.py in test(a, b, cmp, cname)
     21     "`assert` that `cmp(a,b)`; display inputs and `cname or cmp.__name__` if it fails"
     22     if cname is None: cname=cmp.__name__
---> 23     assert cmp(a,b),f"{cname}:\n{a}\n{b}"
     24 
     25 #Cell

/opt/insop_workspace/insop_dkr/fastai/fastai_dev/dev/local/imports.py in equals(a, b)
     76            all_equal      if is_iter(a) or is_iter(b) else
     77            operator.eq)
---> 78     return cmp(a,b)
     79 

/opt/insop_workspace/insop_dkr/fastai/fastai_dev/dev/local/imports.py in all_equal(a, b)
     55     "Compares whether `a` and `b` are the same length and have the same contents"
     56     if not is_iter(b): return False
---> 57     return all(equals(a_,b_) for a_,b_ in itertools.zip_longest(a,b))
     58 
     59 def noop (x=None, *args, **kwargs):

TypeError: zip_longest argument #1 must support iteration
```