### PR TITLE
CSVLogger: add missing run_after indicator

### DIFF
--- a/dev/local/callback/progress.py
+++ b/dev/local/callback/progress.py
@@ -79,7 +79,8 @@ class ShowGraphCallback(Callback):
 
 #Cell
 class CSVLogger(Callback):
-    order=30 #Need to run after the recorder
+    run_after = Recorder
+    order=30
     "Log the results displayed in `learn.path/fname`"
     def __init__(self, fname='history.csv', append=False):
         self.fname,self.append = Path(fname),append

--- a/dev/local/callback/progress.py
+++ b/dev/local/callback/progress.py
@@ -79,7 +79,7 @@ class ShowGraphCallback(Callback):
 
 #Cell
 class CSVLogger(Callback):
-    run_after = Recorder
+    run_after=Recorder
     order=30
     "Log the results displayed in `learn.path/fname`"
     def __init__(self, fname='history.csv', append=False):


### PR DESCRIPTION
CSVLogger was missing the run_after indicator, which can cause an error.