### PR TITLE
added Cat layer

### DIFF
--- a/dev/11_layers.ipynb
+++ b/dev/11_layers.ipynb
@@ -1288,7 +1288,8 @@
     "layers = [ConvLayer(2,4), ConvLayer(2,4), ConvLayer(2,4)]\n",
     "x = torch.rand(1,2,8,8)\n",
     "cat = Cat(layers)\n",
-    "test_eq(cat(x).shape, [1,12,8,8])"
+    "test_eq(cat(x).shape, [1,12,8,8])\n",
+    "test_eq(cat(x), torch.cat([l(x) for l in layers], dim=1))"
    ]
   },
   {

--- a/dev/11_layers.ipynb
+++ b/dev/11_layers.ipynb
@@ -1275,8 +1275,7 @@
     "    def __init__(self, *layers, dim=1): \n",
     "        self.dim=dim\n",
     "        super().__init__(*layers)\n",
-    "    def forward(self, x):\n",
-    "        return torch.cat([l(x) for l in self], dim=self.dim)"
+    "    def forward(self, x): return torch.cat([l(x) for l in self], dim=self.dim)"
    ]
   },
   {

--- a/dev/11_layers.ipynb
+++ b/dev/11_layers.ipynb
@@ -1259,6 +1259,41 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Like sequential Concat \n",
+    "Equivalent to `keras.layers.Concatenate`, it will concat the outputs of a ModuleList over a given dimesion (default the filter dimesion)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Cat(nn.ModuleList):\n",
+    "    \"Concatenate layers outputs over a given dim\"\n",
+    "    def __init__(self, *layers, dim=1): \n",
+    "        self.dim=dim\n",
+    "        super().__init__(*layers)\n",
+    "    def forward(self, x):\n",
+    "        return torch.cat([l(x) for l in self], dim=self.dim)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "layers = [ConvLayer(2,4), ConvLayer(2,4), ConvLayer(2,4)]\n",
+    "x = torch.rand(1,2,8,8)\n",
+    "cat = Cat(layers)\n",
+    "test_eq(cat(x).shape, [1,12,8,8])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Ready-to-go models"
    ]
   },

--- a/dev/11_layers.ipynb
+++ b/dev/11_layers.ipynb
@@ -1269,6 +1269,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#export\n",
     "class Cat(nn.ModuleList):\n",
     "    \"Concatenate layers outputs over a given dim\"\n",
     "    def __init__(self, *layers, dim=1): \n",

--- a/dev/local/layers.py
+++ b/dev/local/layers.py
@@ -4,7 +4,7 @@ __all__ = ['Lambda', 'PartialLambda', 'View', 'ResizeBatch', 'Flatten', 'Debugge
            'AdaptiveConcatPool2d', 'pool_layer', 'PoolFlatten', 'NormType', 'BatchNorm', 'BatchNorm1dFlat', 'BnDropLin',
            'init_default', 'ConvLayer', 'BaseLoss', 'CrossEntropyLossFlat', 'BCEWithLogitsLossFlat', 'BCELossFlat',
            'MSELossFlat', 'trunc_normal_', 'Embedding', 'SelfAttention', 'PooledSelfAttention2d', 'icnr_init',
-           'PixelShuffle_ICNR', 'SequentialEx', 'MergeLayer', 'SimpleCNN', 'ResBlock', 'ParameterModule',
+           'PixelShuffle_ICNR', 'SequentialEx', 'MergeLayer', 'Cat', 'SimpleCNN', 'ResBlock', 'ParameterModule',
            'children_and_parameters', 'TstModule', 'tst', 'children', 'flatten_model']
 
 #Cell
@@ -302,6 +302,15 @@ class MergeLayer(Module):
     "Merge a shortcut with the result of the module by adding them or concatenating them if `dense=True`."
     def __init__(self, dense:bool=False): self.dense=dense
     def forward(self, x): return torch.cat([x,x.orig], dim=1) if self.dense else (x+x.orig)
+
+#Cell
+class Cat(nn.ModuleList):
+    "Concatenate layers outputs over a given dim"
+    def __init__(self, *layers, dim=1):
+        self.dim=dim
+        super().__init__(*layers)
+    def forward(self, x):
+        return torch.cat([l(x) for l in self], dim=self.dim)
 
 #Cell
 class SimpleCNN(nn.Sequential):

--- a/dev/local/layers.py
+++ b/dev/local/layers.py
@@ -309,8 +309,7 @@ class Cat(nn.ModuleList):
     def __init__(self, *layers, dim=1):
         self.dim=dim
         super().__init__(*layers)
-    def forward(self, x):
-        return torch.cat([l(x) for l in self], dim=self.dim)
+    def forward(self, x): return torch.cat([l(x) for l in self], dim=self.dim)
 
 #Cell
 class SimpleCNN(nn.Sequential):

--- a/dev/local/text/core.py
+++ b/dev/local/text/core.py
@@ -279,5 +279,5 @@ class SentencePieceTokenizer():#TODO: pass the special tokens symbol to sp
                 f.write(f'{t}\n')
         return {'sp_model': self.train(raw_text_path)}
 
-    def pipe(self, items):
+    def __call__(self, items):
         for t in items: yield self.tok.EncodeAsPieces(t)


### PR DESCRIPTION
This PR add a Concatenate layer equivalent to `keras.layers.concatenate` to concat the outputs of a list of layers.
This type of layers is useful for architectures of type inception where different kernel sized convs are stacked together.
I inherited from `nn.ModueList` but it could also inherit from fastai `Module`.