### PR TITLE
is_showable should return false on empty lists

### DIFF
--- a/dev/04_transform.ipynb
+++ b/dev/04_transform.ipynb
@@ -1156,7 +1156,7 @@
     "        return ctx\n",
     "    \n",
     "    def _is_showable(self, o):\n",
-    "        return all(hasattr(o_, 'show') for o_ in o) if is_listy(o) else hasattr(o, 'show')"
+    "        return all(hasattr(o_, 'show') for o_ in o) if is_listy(o) and len(o) else hasattr(o, 'show')"
    ]
   },
   {
@@ -1461,6 +1461,16 @@
     "    pipe.split_idx=t\n",
     "    test_eq(pipe.decode(pipe(start)), start)\n",
     "    test_stdout(lambda: pipe.show(pipe(start)), \"-2.0\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check show for empty lists\n",
+    "test_eq(Pipeline()._is_showable([]), False)"
    ]
   },
   {

--- a/dev/local/transform.py
+++ b/dev/local/transform.py
@@ -210,4 +210,4 @@ class Pipeline:
         return ctx
 
     def _is_showable(self, o):
-        return all(hasattr(o_, 'show') for o_ in o) if is_listy(o) else hasattr(o, 'show')
+        return all(hasattr(o_, 'show') for o_ in o) if is_listy(o) and len(o) else hasattr(o, 'show')


### PR DESCRIPTION
_is_showable returns True on an empty list and returns early from Pipeline decode transformation. 
This isn't always ideal, because empty lists cannot be shown. We should give the other Transforms a chance to handle an empty list.

Ran into this error while decoding an empty MultiCategory class

Culprit: `all([])` returns true.