### PR TITLE
Make Transform retain listy type

### DIFF
--- a/dev/01c_transform.ipynb
+++ b/dev/01c_transform.ipynb
@@ -269,7 +269,8 @@
     "        if split_idx!=self.split_idx and self.split_idx is not None: return x\n",
     "        f = getattr(self, fn)\n",
     "        if self.use_as_item or not is_listy(x): return self._do_call(f, x, **kwargs)\n",
-    "        res = tuple(self._do_call(f, x_, **kwargs) for x_ in x)\n",
+    "        g = (self._do_call(f, x_, **kwargs) for x_ in x)\n",
+    "        res = type(x)(g)\n",
     "        return retain_type(res, x)\n",
     "\n",
     "    def _do_call(self, f, x, **kwargs):\n",
@@ -392,6 +393,27 @@
     "def f(x): return x*2\n",
     "test_eq_type(f(2), 4)\n",
     "test_eq_type(f.decode(2.0), 2.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If `as_item` is `False` and an `is_listy` collection is passed then the transform should be applied to each element and returned in the same type of collection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@Transform\n",
+    "def f(x): return x*2\n",
+    "xs = [(1, 2), [1, 2], L(1,2), Tuple(1,2)]\n",
+    "ys = [(2, 4), [2, 4], L(2,4), Tuple(2,4)]\n",
+    "for x,y in zip(xs,ys):\n",
+    "    test_eq_type(f(x), y)"
    ]
   },
   {
@@ -677,10 +699,10 @@
     "def float_to_int(x:(float,int)): return Int(x)\n",
     "\n",
     "f = TupleTransform(float_to_int)\n",
-    "test_eq_type(f([1.]), (Int(1),))\n",
-    "test_eq_type(f([1]), (Int(1),))\n",
-    "test_eq_type(f(['1']), ('1',))\n",
-    "test_eq_type(f([1,'1']), (Int(1),'1'))\n",
+    "test_eq_type(f([1.]), [Int(1),])\n",
+    "test_eq_type(f([1]), [Int(1),])\n",
+    "test_eq_type(f(['1']), ['1',])\n",
+    "test_eq_type(f([1,'1']), [Int(1),'1'])\n",
     "test_eq(f.decode([1]), [1])\n",
     "\n",
     "test_eq_type(f(Tuple(1.)), Tuple(Int(1)))"

--- a/dev/local/core/transform.py
+++ b/dev/local/core/transform.py
@@ -92,7 +92,8 @@ class Transform(metaclass=_TfmMeta):
         if split_idx!=self.split_idx and self.split_idx is not None: return x
         f = getattr(self, fn)
         if self.use_as_item or not is_listy(x): return self._do_call(f, x, **kwargs)
-        res = tuple(self._do_call(f, x_, **kwargs) for x_ in x)
+        g = (self._do_call(f, x_, **kwargs) for x_ in x)
+        res = type(x)(g)
         return retain_type(res, x)
 
     def _do_call(self, f, x, **kwargs):


### PR DESCRIPTION
When a transform gets applied element wise it used to always return
tuple, even though it accepted list and L too.
It's more consistent to return the same type that was passed.

TEST PLAN:
- Added a new test to illustrate the functionality
- Run all notebook tests to check nothing got broken