### PR TITLE
Remove extra cell (perhaps added by mistake)

### DIFF
--- a/dev/08_vision_core.ipynb
+++ b/dev/08_vision_core.ipynb
@@ -249,27 +249,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(6, 2)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "a,b = L([5,2]).map(lambda x: math.floor(x * 4/3))\n",
-    "a,b"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
    "outputs": [],
    "source": [
     "#export\n",


### PR DESCRIPTION
Looks like this is an extra cell inside vision.core. 

Adding this PR to remove this cell from the notebook which also shows in docs here:
http://dev.fast.ai/vision.core.html#Image.reshape