### PR TITLE
fix RegexLabeller obj has no attr __name__

### DIFF
--- a/dev/01b_core_dispatch.ipynb
+++ b/dev/01b_core_dispatch.ipynb
@@ -233,7 +233,7 @@
     "\n",
     "    def _attname(self,k): return getattr(k,'__name__',str(k))\n",
     "    def __repr__(self):\n",
-    "        r = [f'({self._attname(k)},{self._attname(l)}) -> {v.__name__}'\n",
+    "        r = [f'({self._attname(k)},{self._attname(l)}) -> {getattr(v, \"__name__\", v.__class__.__name__)}'\n",
     "             for k in self.funcs.d for l,v in self.funcs[k].d.items()]\n",
     "        return '\\n'.join(r)\n",
     "\n",

--- a/dev/local/core/dispatch.py
+++ b/dev/local/core/dispatch.py
@@ -86,7 +86,7 @@ class TypeDispatch:
 
     def _attname(self,k): return getattr(k,'__name__',str(k))
     def __repr__(self):
-        r = [f'({self._attname(k)},{self._attname(l)}) -> {v.__name__}'
+        r = [f'({self._attname(k)},{self._attname(l)}) -> {getattr(v, "__name__", v.__class__.__name__)}'
              for k in self.funcs.d for l,v in self.funcs[k].d.items()]
         return '\n'.join(r)
 


### PR DESCRIPTION
While looking into `DataSource` I got an error 

```
AttributeError: 'RegexLabeller' object has no attribute '__name__'
```

This can be replicated by:

```
path = untar_data(URLs.PETS); path

np.random.seed(2)
pat = r'/([^/]+)_\d+.jpg$'

items = get_image_files(path/'images')
tfms = L([PILBase.create], [RegexLabeller(pat), Categorize])
splits = RandomSplitter(0.2)(items)
dsrc = DataSource(items, tfms=tfms, splits=splits)

dsrc.tls
```

From what I understand, issue occurs due to calling `__name__` on RegexLabeller() and this PR attempts to fix it. 