### PR TITLE
Fixed broken link to fastai Style Guide

### DIFF
--- a/dev_nb/001b_fit.ipynb
+++ b/dev_nb/001b_fit.ipynb
@@ -126,7 +126,7 @@
     "\n",
     "[Here is a reference](https://github.com/fastai/fastai/blob/master/docs/abbr.md) for these and other abbreviations used as variable names. \n",
     "\n",
-    "The fast.ai library differs from PEP 8 and instead follows conventions developed around the [APL](https://en.wikipedia.org/wiki/APL_\\(programming_language\\)) / [J](https://en.wikipedia.org/wiki/J_\\(programming_language\\)) / [K](https://en.wikipedia.org/wiki/K_\\(programming_language\\)) programming languages (all of which are centered around multi-dimensional arrays), which are more concise and closer to math notation. [Here is a more detailed explanation](https://github.com/fastai/fastai/blob/master/docs/style.md) of the fast.ai style guide."
+    "The fast.ai library differs from PEP 8 and instead follows conventions developed around the [APL](https://en.wikipedia.org/wiki/APL_\\(programming_language\\)) / [J](https://en.wikipedia.org/wiki/J_\\(programming_language\\)) / [K](https://en.wikipedia.org/wiki/K_\\(programming_language\\)) programming languages (all of which are centered around multi-dimensional arrays), which are more concise and closer to math notation. [Here is a more detailed explanation](https://github.com/fastai/fastai/blob/master/docs/dev/style.md) of the fast.ai style guide."
    ]
   },
   {


### PR DESCRIPTION
/docs/dev/style.md instead of /docs/style.md