### PR TITLE
swift: support `PythonKit` and `Python`

### DIFF
--- a/swift/00a_intro_and_float.ipynb
+++ b/swift/00a_intro_and_float.ipynb
@@ -589,7 +589,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/01_matmul.ipynb
+++ b/swift/01_matmul.ipynb
@@ -397,7 +397,11 @@
     }
    ],
    "source": [
-    "import Python\n",
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n",
     "let np = Python.import(\"numpy\")\n",
     "let pickle = Python.import(\"pickle\")\n",
     "let sys = Python.import(\"sys\")\n",

--- a/swift/05_anneal.ipynb
+++ b/swift/05_anneal.ipynb
@@ -231,7 +231,11 @@
    "outputs": [],
    "source": [
     "// export\n",
-    "import Python\n",
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n",
     "public let np = Python.import(\"numpy\")\n",
     "public let plt = Python.import(\"matplotlib.pyplot\")"
    ]

--- a/swift/05b_early_stopping.ipynb
+++ b/swift/05b_early_stopping.ipynb
@@ -90,7 +90,11 @@
     "//export\n",
     "import Path\n",
     "import TensorFlow\n",
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/06_cuda.ipynb
+++ b/swift/06_cuda.ipynb
@@ -187,7 +187,11 @@
     "//export\n",
     "import Path\n",
     "import TensorFlow\n",
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/07_batchnorm.ipynb
+++ b/swift/07_batchnorm.ipynb
@@ -19,7 +19,11 @@
     "//export\n",
     "import Path\n",
     "import TensorFlow\n",
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/07b_batchnorm_lesson.ipynb
+++ b/swift/07b_batchnorm_lesson.ipynb
@@ -282,7 +282,11 @@
     "//export\n",
     "import Path\n",
     "import TensorFlow\n",
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/08_data_block.ipynb
+++ b/swift/08_data_block.ipynb
@@ -336,7 +336,11 @@
     "//export\n",
     "import Path\n",
     "import TensorFlow\n",
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/08b_data_block_opencv.ipynb
+++ b/swift/08b_data_block_opencv.ipynb
@@ -44,7 +44,11 @@
     "//export\n",
     "import Path\n",
     "import TensorFlow\n",
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/08c_data_block-lightlyfunctional.ipynb
+++ b/swift/08c_data_block-lightlyfunctional.ipynb
@@ -43,7 +43,11 @@
    "source": [
     "import Path\n",
     "import TensorFlow\n",
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/08c_data_block_generic.ipynb
+++ b/swift/08c_data_block_generic.ipynb
@@ -44,7 +44,11 @@
     "//export\n",
     "import Path\n",
     "import TensorFlow\n",
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/FastaiNotebook_05_anneal/Sources/FastaiNotebook_05_anneal/05_anneal.swift
+++ b/swift/FastaiNotebook_05_anneal/Sources/FastaiNotebook_05_anneal/05_anneal.swift
@@ -9,7 +9,11 @@ file to edit: 05_anneal.ipynb
 import Path
 import TensorFlow
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 public let np = Python.import("numpy")
 public let plt = Python.import("matplotlib.pyplot")
 

--- a/swift/FastaiNotebook_05b_early_stopping/Sources/FastaiNotebook_05b_early_stopping/05_anneal.swift
+++ b/swift/FastaiNotebook_05b_early_stopping/Sources/FastaiNotebook_05b_early_stopping/05_anneal.swift
@@ -9,7 +9,11 @@ file to edit: 05_anneal.ipynb
 import Path
 import TensorFlow
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 public let np = Python.import("numpy")
 public let plt = Python.import("matplotlib.pyplot")
 

--- a/swift/FastaiNotebook_05b_early_stopping/Sources/FastaiNotebook_05b_early_stopping/05b_early_stopping.swift
+++ b/swift/FastaiNotebook_05b_early_stopping/Sources/FastaiNotebook_05b_early_stopping/05b_early_stopping.swift
@@ -8,7 +8,11 @@ file to edit: 05b_early_stopping.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 //TODO: when recorder can be accessed as a property, remove it from the return
 extension Learner where Opt.Scalar: PythonConvertible {

--- a/swift/FastaiNotebook_06_cuda/Sources/FastaiNotebook_06_cuda/05_anneal.swift
+++ b/swift/FastaiNotebook_06_cuda/Sources/FastaiNotebook_06_cuda/05_anneal.swift
@@ -9,7 +9,11 @@ file to edit: 05_anneal.ipynb
 import Path
 import TensorFlow
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 public let np = Python.import("numpy")
 public let plt = Python.import("matplotlib.pyplot")
 

--- a/swift/FastaiNotebook_06_cuda/Sources/FastaiNotebook_06_cuda/05b_early_stopping.swift
+++ b/swift/FastaiNotebook_06_cuda/Sources/FastaiNotebook_06_cuda/05b_early_stopping.swift
@@ -8,7 +8,11 @@ file to edit: 05b_early_stopping.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 //TODO: when recorder can be accessed as a property, remove it from the return
 extension Learner where Opt.Scalar: PythonConvertible {

--- a/swift/FastaiNotebook_06_cuda/Sources/FastaiNotebook_06_cuda/06_cuda.swift
+++ b/swift/FastaiNotebook_06_cuda/Sources/FastaiNotebook_06_cuda/06_cuda.swift
@@ -8,7 +8,11 @@ file to edit: 06_cuda.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 extension Learner {
     public class AddChannel: Delegate {

--- a/swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/05_anneal.swift
+++ b/swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/05_anneal.swift
@@ -9,7 +9,11 @@ file to edit: 05_anneal.ipynb
 import Path
 import TensorFlow
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 public let np = Python.import("numpy")
 public let plt = Python.import("matplotlib.pyplot")
 

--- a/swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/05b_early_stopping.swift
+++ b/swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/05b_early_stopping.swift
@@ -8,7 +8,11 @@ file to edit: 05b_early_stopping.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 //TODO: when recorder can be accessed as a property, remove it from the return
 extension Learner where Opt.Scalar: PythonConvertible {

--- a/swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/06_cuda.swift
+++ b/swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/06_cuda.swift
@@ -8,7 +8,11 @@ file to edit: 06_cuda.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 extension Learner {
     public class AddChannel: Delegate {

--- a/swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/07_batchnorm.swift
+++ b/swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/07_batchnorm.swift
@@ -8,7 +8,11 @@ file to edit: 07_batchnorm.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public class Reference<T> {
     public var value: T

--- a/swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/05_anneal.swift
+++ b/swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/05_anneal.swift
@@ -9,7 +9,11 @@ file to edit: 05_anneal.ipynb
 import Path
 import TensorFlow
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 public let np = Python.import("numpy")
 public let plt = Python.import("matplotlib.pyplot")
 

--- a/swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/05b_early_stopping.swift
+++ b/swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/05b_early_stopping.swift
@@ -8,7 +8,11 @@ file to edit: 05b_early_stopping.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 //TODO: when recorder can be accessed as a property, remove it from the return
 extension Learner where Opt.Scalar: PythonConvertible {

--- a/swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/06_cuda.swift
+++ b/swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/06_cuda.swift
@@ -8,7 +8,11 @@ file to edit: 06_cuda.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 extension Learner {
     public class AddChannel: Delegate {

--- a/swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/07_batchnorm.swift
+++ b/swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/07_batchnorm.swift
@@ -8,7 +8,11 @@ file to edit: 07_batchnorm.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public class Reference<T> {
     public var value: T

--- a/swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/08_data_block.swift
+++ b/swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/08_data_block.swift
@@ -8,7 +8,11 @@ file to edit: 08_data_block.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public let dataPath = Path.home/".fastai"/"data"
 

--- a/swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/05_anneal.swift
+++ b/swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/05_anneal.swift
@@ -9,7 +9,11 @@ file to edit: 05_anneal.ipynb
 import Path
 import TensorFlow
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 public let np = Python.import("numpy")
 public let plt = Python.import("matplotlib.pyplot")
 

--- a/swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/05b_early_stopping.swift
+++ b/swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/05b_early_stopping.swift
@@ -8,7 +8,11 @@ file to edit: 05b_early_stopping.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 //TODO: when recorder can be accessed as a property, remove it from the return
 extension Learner where Opt.Scalar: PythonConvertible {

--- a/swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/06_cuda.swift
+++ b/swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/06_cuda.swift
@@ -8,7 +8,11 @@ file to edit: 06_cuda.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 extension Learner {
     public class AddChannel: Delegate {

--- a/swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/07_batchnorm.swift
+++ b/swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/07_batchnorm.swift
@@ -8,7 +8,11 @@ file to edit: 07_batchnorm.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public class Reference<T> {
     public var value: T

--- a/swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/08_data_block.swift
+++ b/swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/08_data_block.swift
@@ -8,7 +8,11 @@ file to edit: 08_data_block.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public let dataPath = Path.home/".fastai"/"data"
 

--- a/swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/05_anneal.swift
+++ b/swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/05_anneal.swift
@@ -9,7 +9,11 @@ file to edit: 05_anneal.ipynb
 import Path
 import TensorFlow
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 public let np = Python.import("numpy")
 public let plt = Python.import("matplotlib.pyplot")
 

--- a/swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/05b_early_stopping.swift
+++ b/swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/05b_early_stopping.swift
@@ -8,7 +8,11 @@ file to edit: 05b_early_stopping.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 //TODO: when recorder can be accessed as a property, remove it from the return
 extension Learner where Opt.Scalar: PythonConvertible {

--- a/swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/06_cuda.swift
+++ b/swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/06_cuda.swift
@@ -8,7 +8,11 @@ file to edit: 06_cuda.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 extension Learner {
     public class AddChannel: Delegate {

--- a/swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/07_batchnorm.swift
+++ b/swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/07_batchnorm.swift
@@ -8,7 +8,11 @@ file to edit: 07_batchnorm.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public class Reference<T> {
     public var value: T

--- a/swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/08c_data_block_generic.swift
+++ b/swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/08c_data_block_generic.swift
@@ -8,7 +8,11 @@ file to edit: 08c_data_block_generic.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public let dataPath = Path.home/".fastai"/"data"
 

--- a/swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/05_anneal.swift
+++ b/swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/05_anneal.swift
@@ -9,7 +9,11 @@ file to edit: 05_anneal.ipynb
 import Path
 import TensorFlow
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 public let np = Python.import("numpy")
 public let plt = Python.import("matplotlib.pyplot")
 

--- a/swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/05b_early_stopping.swift
+++ b/swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/05b_early_stopping.swift
@@ -8,7 +8,11 @@ file to edit: 05b_early_stopping.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 //TODO: when recorder can be accessed as a property, remove it from the return
 extension Learner where Opt.Scalar: PythonConvertible {

--- a/swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/06_cuda.swift
+++ b/swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/06_cuda.swift
@@ -8,7 +8,11 @@ file to edit: 06_cuda.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 extension Learner {
     public class AddChannel: Delegate {

--- a/swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/07_batchnorm.swift
+++ b/swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/07_batchnorm.swift
@@ -8,7 +8,11 @@ file to edit: 07_batchnorm.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public class Reference<T> {
     public var value: T

--- a/swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/08_data_block.swift
+++ b/swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/08_data_block.swift
@@ -8,7 +8,11 @@ file to edit: 08_data_block.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public let dataPath = Path.home/".fastai"/"data"
 

--- a/swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/05_anneal.swift
+++ b/swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/05_anneal.swift
@@ -9,7 +9,11 @@ file to edit: 05_anneal.ipynb
 import Path
 import TensorFlow
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 public let np = Python.import("numpy")
 public let plt = Python.import("matplotlib.pyplot")
 

--- a/swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/05b_early_stopping.swift
+++ b/swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/05b_early_stopping.swift
@@ -8,7 +8,11 @@ file to edit: 05b_early_stopping.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 //TODO: when recorder can be accessed as a property, remove it from the return
 extension Learner where Opt.Scalar: PythonConvertible {

--- a/swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/06_cuda.swift
+++ b/swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/06_cuda.swift
@@ -8,7 +8,11 @@ file to edit: 06_cuda.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 extension Learner {
     public class AddChannel: Delegate {

--- a/swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/07_batchnorm.swift
+++ b/swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/07_batchnorm.swift
@@ -8,7 +8,11 @@ file to edit: 07_batchnorm.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public class Reference<T> {
     public var value: T

--- a/swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/08_data_block.swift
+++ b/swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/08_data_block.swift
@@ -8,7 +8,11 @@ file to edit: 08_data_block.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public let dataPath = Path.home/".fastai"/"data"
 

--- a/swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/05_anneal.swift
+++ b/swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/05_anneal.swift
@@ -9,7 +9,11 @@ file to edit: 05_anneal.ipynb
 import Path
 import TensorFlow
 
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 public let np = Python.import("numpy")
 public let plt = Python.import("matplotlib.pyplot")
 

--- a/swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/05b_early_stopping.swift
+++ b/swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/05b_early_stopping.swift
@@ -8,7 +8,11 @@ file to edit: 05b_early_stopping.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 //TODO: when recorder can be accessed as a property, remove it from the return
 extension Learner where Opt.Scalar: PythonConvertible {

--- a/swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/06_cuda.swift
+++ b/swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/06_cuda.swift
@@ -8,7 +8,11 @@ file to edit: 06_cuda.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 extension Learner {
     public class AddChannel: Delegate {

--- a/swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/07_batchnorm.swift
+++ b/swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/07_batchnorm.swift
@@ -8,7 +8,11 @@ file to edit: 07_batchnorm.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public class Reference<T> {
     public var value: T

--- a/swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/08_data_block.swift
+++ b/swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/08_data_block.swift
@@ -8,7 +8,11 @@ file to edit: 08_data_block.ipynb
 
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 
 public let dataPath = Path.home/".fastai"/"data"
 

--- a/swift/MinimalDsBug.ipynb
+++ b/swift/MinimalDsBug.ipynb
@@ -7,7 +7,11 @@
    "outputs": [],
    "source": [
     "import TensorFlow\n",
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/SwiftCV/Extra/Tests.ipynb
+++ b/swift/SwiftCV/Extra/Tests.ipynb
@@ -69,7 +69,11 @@
    "source": [
     "%include \"EnableIPythonDisplay.swift\"\n",
     "import Foundation\n",
-    "import Python\n",
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n",
     "import TensorFlow\n",
     "import SwiftCV\n",
     "\n",

--- a/swift/c_interop_examples.ipynb
+++ b/swift/c_interop_examples.ipynb
@@ -190,7 +190,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import Python"
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n"
    ]
   },
   {

--- a/swift/datablock/Sources/datablock/main.swift
+++ b/swift/datablock/Sources/datablock/main.swift
@@ -1,6 +1,10 @@
 import Path
 import TensorFlow
-import Python
+#if canImport(PythonKit)
+    import PythonKit
+#else
+    import Python
+#endif
 import FastaiNotebook_08c_data_block_generic
 import SwiftCV
 SetNumThreads(0)

--- a/swift/opencv_integration_example.ipynb
+++ b/swift/opencv_integration_example.ipynb
@@ -263,7 +263,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import Python\n",
+    "#if canImport(PythonKit)\n",
+    "    import PythonKit\n",
+    "#else\n",
+    "    import Python\n",
+    "#endif\n",
     "import TensorFlow"
    ]
   },


### PR DESCRIPTION
Enable building against PythonKit, and prefer that if it is available.